### PR TITLE
suppress deprecation warnings from sequelize

### DIFF
--- a/bulletin-board-app/backend/db.js
+++ b/bulletin-board-app/backend/db.js
@@ -12,8 +12,10 @@ var sequelize = new Sequelize(dbConfig.connection.dbName, dbConfig.connection.us
         max: dbConfig.pool.max
     },
     dialectOptions: {
-        requestTimeout: 30000
-    }    
+        requestTimeout: 30000,
+        encrypt: false
+    },
+    operatorsAliases: false
 });
 
 sequelize


### PR DESCRIPTION
per https://github.com/sequelize/sequelize/issues/8417
and https://github.com/sequelize/sequelize/issues/9574

nothing is technically broken, but the part of the image building exercise where we check service logs to determine if the configs and secrets we mounted in actually did anything is overwhelmed by a bunch of deprecation warnings that just confuses the point we're trying to make. This suppresses those so we only see the `info:` and `debug:` messages we actually care about.

@sixeyed you're closer to metal on this bulletin board app; are there any reasons why this is a Dumb Idea? PTAL, thanks!