### PR TITLE
Update Dockerfile

### DIFF
--- a/bulletin-board-app/Dockerfile
+++ b/bulletin-board-app/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6.11.5
+FROM node:12
 
 WORKDIR /usr/src/app
 COPY package.json .


### PR DESCRIPTION
Since node 6 is no longer supported. Node.JS 12 is the actual LTS version.